### PR TITLE
docs: Update config guide and change docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,14 +58,14 @@ $ git gc --aggressive --prune=now
 * [电视直播](https://github.com/mytv-android/mytv-android) 2.0.0.184测试版，ts2hls模式时移进度有Bug，EPG识别逻辑比较奇怪，[Issues#230](https://github.com/mytv-android/mytv-android/issues/230) 已修复对本项目EPG数据的兼容性
 * ~~[我的电视 2.2.7](https://github.com/yaoxieyoulei/mytv-android) 和 [天光云影 3.3.10](https://t.me/mytv_android_release) 不支持HTTP协议的时移，原生RTSP流待确认~~
 * [云影空蒙 3.6.5-1](https://t.me/YYKM_release/46) rtp2httpd代理的RTSP流调整时移进度有一些小Bug，ts2hls模式效果完美，本节目单项目提供的其余所有功能均完美支持
-* [rtp2httpd m3u播放列表集成](https://github.com/stackia/rtp2httpd/blob/main/docs/m3u-integration.md) 使用组播节目单 [iptv-multicast.m3u](https://github.com/zzzz0317/beijing-unicom-iptv-playlist/raw/refs/heads/main/iptv-multicast.m3u) 非常完美。版本 >= v3.10.1 可以支持 HLS 流代理，但自带网页播放器播放 HLS 流时由于存在起播速度较慢、部分浏览器自身不支持、与部分流兼容性不佳等问题因此仍建议继续采用组播节目单
+* [rtp2httpd m3u播放列表集成](https://rtp2httpd.com/guide/m3u-integration) 使用组播节目单 [iptv-multicast.m3u](https://github.com/zzzz0317/beijing-unicom-iptv-playlist/raw/refs/heads/main/iptv-multicast.m3u) 非常完美。版本 >= v3.10.1 可以支持 HLS 流代理，但自带网页播放器播放 HLS 流时由于存在起播速度较慢、部分浏览器自身不支持、与部分流兼容性不佳等问题因此仍建议继续采用组播节目单
 
 欢迎网友测试并提供反馈。
 
 ## 文件说明
 
 * [iptv-multicast.m3u](https://github.com/zzzz0317/beijing-unicom-iptv-playlist/raw/refs/heads/main/iptv-multicast.m3u): 带有组播地址的播放列表，通过 [zzzz0317/beijing-unicom-iptv-playlist-sniffer](https://github.com/zzzz0317/beijing-unicom-iptv-playlist-sniffer/) 抓取
-* [iptv-unicast.m3u](https://github.com/zzzz0317/beijing-unicom-iptv-playlist/raw/refs/heads/main/iptv-unicast.m3u): 转换为单播地址的播放列表，需要使本地网络能解析 `iptv.local` 域名到您可访问的 IPTV 代理程序实例（如 `udpxy`、`rtp2httpd`、`msd_lite` 等），您也可以将文件中的 `iptv.local` 替换为您可访问的 IPTV 代理程序实例地址
+* [iptv-unicast.m3u](https://github.com/zzzz0317/beijing-unicom-iptv-playlist/raw/refs/heads/main/iptv-unicast.m3u): 转换为单播地址的播放列表，需要使本地网络能解析 `iptv.local` 域名到您可访问的 IPTV 代理程序实例（如 `rtp2httpd`、`msd_lite`、`udpxy` 等），您也可以将文件中的 `iptv.local` 替换为您可访问的 IPTV 代理程序实例地址
 * [iptv-unicast-timeshift-ts2hls.m3u](https://github.com/zzzz0317/beijing-unicom-iptv-playlist/raw/refs/heads/main/iptv-unicast-timeshift-ts2hls.m3u): 转换为单播地址的播放列表，同上，但时移源变成了不经过 HTTP 代理的 `ts2hls` 模式
 * [epg.xml](https://github.com/zzzz0317/beijing-unicom-iptv-playlist/raw/refs/heads/main/epg.xml): 节目指南数据，通过 [zzzz0317/beijing-unicom-iptv-playlist-sniffer epg.py](https://github.com/zzzz0317/beijing-unicom-iptv-playlist-sniffer/blob/main/epg.py) 抓取
 * [epg.xml.gz](https://github.com/zzzz0317/beijing-unicom-iptv-playlist/raw/refs/heads/main/epg.xml.gz): 上面那个文件的压缩版，节目单中自动调用此文件
@@ -81,7 +81,7 @@ $ git gc --aggressive --prune=now
 |文件名称|Sniffer配置对应|地址|时移|说明|
 |-----|-----|-----|-----|-----|
 |[iptv-unicast.m3u](https://github.com/zzzz0317/beijing-unicom-iptv-playlist/raw/refs/heads/main/iptv-unicast.m3u)|playlist_save_path|HTTP转组播|HTTP转RTSP|**推荐**|
-|[iptv-multicast.m3u](https://github.com/zzzz0317/beijing-unicom-iptv-playlist/raw/refs/heads/main/iptv-multicast.m3u)|playlist_mc_save_path|组播|RTSP|**推荐**，光猫路由模式、[rtp2httpd播放列表集成](https://github.com/stackia/rtp2httpd/blob/main/docs/m3u-integration.md) 可直接使用|
+|[iptv-multicast.m3u](https://github.com/zzzz0317/beijing-unicom-iptv-playlist/raw/refs/heads/main/iptv-multicast.m3u)|playlist_mc_save_path|组播|RTSP|**推荐**，光猫路由模式、[rtp2httpd播放列表集成](https://rtp2httpd.com/guide/m3u-integration) 可直接使用|
 |[iptv-ignored-unicast.m3u](https://github.com/zzzz0317/beijing-unicom-iptv-playlist/raw/refs/heads/main/iptv-ignored-unicast.m3u)|playlist_ignored_save_path|HTTP转组播|HTTP转RTSP|已忽略的频道列表，大概没用|
 |[iptv-ignored-multicast.m3u](https://github.com/zzzz0317/beijing-unicom-iptv-playlist/raw/refs/heads/main/iptv-ignored-multicast.m3u)|playlist_ignored_mc_save_path|组播|RTSP|已忽略的频道列表，大概没用|
 |[iptv-rtsp.m3u](https://github.com/zzzz0317/beijing-unicom-iptv-playlist/raw/refs/heads/main/iptv-rtsp.m3u)|playlist_rtsp_save_path|HTTP转RTSP|HTTP转RTSP|[我的电视](https://github.com/yaoxieyoulei/mytv-android)及其分支可使用时移|
@@ -109,11 +109,11 @@ $ git gc --aggressive --prune=now
 | Key                              | 直播/时移 | 解释                                                     |
 |----------------------------------|-----------|----------------------------------------------------------|
 | `bjunicom-multicast`             | 仅直播    | 组播直播源                                               |
-| `bjunicom-multicast-httpproxy`   | 仅直播    | 由 udpxy 或 rtp2httpd 代理的组播直播源                   |
+| `bjunicom-multicast-httpproxy`   | 仅直播    | 由 `rtp2httpd`、`msd_lite`、`udpxy` 等软件代理的组播直播源 |
 | `bjunicom-rtsp`                  | 直播+时移 | RTSP 直播源，**不推荐用于直播**                          |
-| `bjunicom-rtsp-httpproxy`        | 直播+时移 | 由 rtp2httpd 代理的 RTSP 直播源，**不推荐用于直播**      |
+| `bjunicom-rtsp-httpproxy`        | 直播+时移 | 由 `rtp2httpd` 代理的 RTSP 直播源，**不推荐用于直播**      |
 | `bjunicom-rtsp-ts2hls`           | 直播+时移 | 由 RTSP 地址转换成的 TS2HLS 地址，**非常不推荐用于直播** |
-| `bjunicom-rtsp-ts2hls-httpproxy` | 直播+时移 | 由 rtp2httpd 代理的 TS2HLS 地址，**非常不推荐用于直播** |
+| `bjunicom-rtsp-ts2hls-httpproxy` | 直播+时移 | 由 `rtp2httpd` 代理的 TS2HLS 地址，**非常不推荐用于直播** |
 
 命令帮助信息：
 
@@ -145,12 +145,12 @@ options:
 $ python generator.py convert playlist-zz.json --output iptv.m3u
 ```
 
-完整示例（假设您的服务器 IP 地址为 10.1.1.1，并且在该服务器上安装了 udpxy 和 Nginx）：
+完整示例（假设您的服务器 IP 地址为 10.1.1.1，并且在该服务器上安装并运行了 `rtp2httpd` 和 `Nginx`）：
 
 ```bash
 $ python generator.py convert playlist-zz.json \
-  --key-live bjunicom-multicast-httpproxy bjunicom-rtsp-ts2hls \
-  --key-timeshift bjunicom-rtsp-ts2hls bjunicom-rtsp \
+  --key-live bjunicom-multicast-httpproxy \
+  --key-timeshift bjunicom-rtsp-httpproxy \
   --rtp-proxy-url http://10.1.1.1:8081/rtp/ \
   --rtsp-proxy-url http://10.1.1.1:8081/rtsp/ \
   --http-proxy-url http://10.1.1.1:8081/http/ \
@@ -302,7 +302,7 @@ server {
     # root 指定为本项目根目录
     root /var/www/iptv;
 
-    # 指向 udpxy
+    # 指向 IPTV 代理程序实例（如 rtp2httpd、msd_lite、udpxy 等）
     location /rtp {
         proxy_redirect off;
         proxy_set_header X-Real-IP $remote_addr;
@@ -339,7 +339,7 @@ server {
 
 **⚠️ 注意：此方法已弃用，未来可能删除，请使用 `generator.py convert` 代替。**
 
-适用于自部署 Web 服务的情况，以下示例假设您的服务器 IP 地址为 10.1.1.1，并且在该服务器上安装了 udpxy 和 Nginx
+适用于自部署 Web 服务的情况，以下示例假设您的服务器 IP 地址为 10.1.1.1，并且在该服务器上安装并运行了 IPTV 代理程序（如 `rtp2httpd`、`msd_lite`、`udpxy` 等）和 `Nginx`
 
 转换: `./convert.py --rtp-url http://10.1.1.1:8081/rtp/ --epg-url http://10.1.1.1:8081/epg.xml.gz --logo-url http://10.1.1.1:8081/img/ --output iptv.m3u`
 


### PR DESCRIPTION
1. 优化配置指南，优先推荐可支持回看（RTSP/HLS）、支持跨平台（Linux/FreeBSD/macOS）的 rtp2httpd 作为默认配置。同时修正不同时期撰写的文档对 IPTV 代理程序的不同描述。
2. 修正部分近期因 rtp2httpd 官网上线导致更改的链接地址，将其指向官网地址。